### PR TITLE
fix: Add Windows compatibility for setup_manager and aliases

### DIFF
--- a/install/aliases.py
+++ b/install/aliases.py
@@ -8,7 +8,7 @@ Example: generate-codebase-md.sh -> gcm
 
 import os
 import sys
-import subprocess
+import shutil
 from pathlib import Path
 
 def print_status(msg):
@@ -54,11 +54,7 @@ def generate_alias(script_name):
 
 def check_command_exists(cmd):
     """Check if a command already exists in the system."""
-    try:
-        subprocess.run(['which', cmd], capture_output=True, check=True)
-        return True
-    except subprocess.CalledProcessError:
-        return False
+    return shutil.which(cmd) is not None
 
 def get_existing_aliases():
     """Read existing aliases from ~/.tools_aliases."""
@@ -131,11 +127,13 @@ def main():
     
     print_status(f"Scanning scripts in: {scripts_path}")
     
-    # Get all executable files in scripts directory
+    # Get all script files in scripts directory
     scripts = []
     for file in scripts_path.iterdir():
-        if file.is_file() and os.access(file, os.X_OK):
-            scripts.append(file)
+        if file.is_file():
+            # On Windows os.access(X_OK) is unreliable; include all script files
+            if sys.platform == "win32" or os.access(file, os.X_OK):
+                scripts.append(file)
     
     if not scripts:
         print_status("No executable scripts found")

--- a/install/claude-code.sh
+++ b/install/claude-code.sh
@@ -92,7 +92,8 @@ install_claude_code() {
 
     print_status "Setting npm prefix to $npm_prefix..."
     npm config set prefix "$npm_prefix"
-    export PATH="$npm_prefix/bin:$PATH"
+    # On Windows, npm puts binaries directly in the prefix dir (no /bin/ subdirectory)
+    export PATH="$npm_prefix/bin:$npm_prefix:$PATH"
 
     if npm install -g @anthropic-ai/claude-code; then
         print_success "Claude Code CLI installed via npm to $npm_prefix"
@@ -115,7 +116,7 @@ install_claude_code() {
         source "$HOME/.zshrc" 2>/dev/null || true
     fi
 
-    if command -v claude >/dev/null 2>&1 || [ -x "$HOME/.claude/bin/claude" ] || [ -x "$npm_prefix/bin/claude" ]; then
+    if command -v claude >/dev/null 2>&1 || [ -x "$HOME/.claude/bin/claude" ] || [ -x "$npm_prefix/bin/claude" ] || [ -x "$npm_prefix/claude" ]; then
         print_success "Claude Code CLI installation verified"
         print_status "Run 'claude login' to authenticate"
         return 0

--- a/install/codex.sh
+++ b/install/codex.sh
@@ -119,7 +119,8 @@ install_codex() {
 
         print_status "Setting npm prefix to $npm_prefix..."
         npm config set prefix "$npm_prefix"
-        export PATH="$npm_prefix/bin:$PATH"
+        # On Windows, npm puts binaries directly in the prefix dir (no /bin/ subdirectory)
+        export PATH="$npm_prefix/bin:$npm_prefix:$PATH"
 
         # Install Codex CLI
         if npm install -g @openai/codex 2>/dev/null; then
@@ -168,7 +169,7 @@ install_codex() {
 
     # Verify installation
     local npm_prefix="$HOME/.npm-global"
-    if command -v codex >/dev/null 2>&1 || [ -x "$HOME/.codex/bin/codex" ] || [ -x "$npm_prefix/bin/codex" ]; then
+    if command -v codex >/dev/null 2>&1 || [ -x "$HOME/.codex/bin/codex" ] || [ -x "$npm_prefix/bin/codex" ] || [ -x "$npm_prefix/codex" ]; then
         print_success "Codex CLI installation verified"
         print_status "Run 'codex' to start and authenticate with ChatGPT plan or API key"
         return 0

--- a/install/coding_tools_installer.py
+++ b/install/coding_tools_installer.py
@@ -452,6 +452,18 @@ Examples:
         help="Update already installed tools to latest versions"
     )
 
+    parser.add_argument(
+        "--verbose", "-v",
+        action="store_true",
+        help="Show detailed output during installation"
+    )
+
+    parser.add_argument(
+        "--no-auto-sudo",
+        action="store_true",
+        help="Disable automatic sudo retry on permission errors"
+    )
+
     args = parser.parse_args()
 
     try:

--- a/install/rust.sh
+++ b/install/rust.sh
@@ -140,6 +140,12 @@ install_prerequisites() {
                 read -r
             fi
             ;;
+        MINGW*|MSYS*|CYGWIN*)
+            # Windows (Git Bash / MSYS2 / Cygwin)
+            # rustup handles Windows build tools automatically
+            print_status "Windows detected via Git Bash - skipping prerequisite installation"
+            print_status "rustup will configure the appropriate toolchain"
+            ;;
         *)
             print_error "Unsupported OS: $os_type"
             exit 1

--- a/setup_manager.py
+++ b/setup_manager.py
@@ -8,6 +8,7 @@ import os
 import sys
 import subprocess
 import platform
+import shutil
 import time
 from pathlib import Path
 from typing import List, Tuple, Optional
@@ -65,9 +66,11 @@ class SetupManager:
 
         self.scripts_path = self.script_dir / "scripts"
         self.install_path = self.script_dir / "install"
-        self.shell_config = Path.home() / ".zshrc"
         self.path_marker = "# Added by tools repository setup"
         self.os_type = self._detect_os()
+        self.is_windows = self.os_type == "Windows"
+        self.path_sep = ";" if self.is_windows else ":"
+        self.shell_config = self._get_shell_config()
         self.results: List[InstallResult] = []
 
         # Optional flags (set by main())
@@ -75,6 +78,11 @@ class SetupManager:
         self.commands_local = ""
         self.local_dir = str(Path.cwd())
         self.verbose = False
+
+        # Cache bash path on Windows
+        self._bash_path: Optional[str] = None
+        if self.is_windows:
+            self._bash_path = self._find_bash()
 
     def _detect_os(self) -> str:
         """Detect the operating system"""
@@ -87,6 +95,37 @@ class SetupManager:
             return "Windows"
         else:
             return "Unknown"
+
+    def _get_shell_config(self) -> Path:
+        """Get the appropriate shell config file for the OS"""
+        if self.os_type == "Windows":
+            # On Windows, still create .zshrc for WSL/Git Bash interop
+            return Path.home() / ".zshrc"
+        return Path.home() / ".zshrc"
+
+    def _find_bash(self) -> Optional[str]:
+        """Find a usable bash executable on Windows"""
+        # Prefer Git Bash as it handles Windows paths natively
+        git_bash_paths = [
+            r"C:\Program Files\Git\bin\bash.exe",
+            r"C:\Program Files (x86)\Git\bin\bash.exe",
+        ]
+        for p in git_bash_paths:
+            if os.path.isfile(p):
+                return p
+
+        # Fall back to any bash on PATH (e.g. WSL bash)
+        bash = shutil.which("bash")
+        if bash:
+            return bash
+
+        return None
+
+    def _get_cargo_home(self) -> str:
+        """Get the Cargo home directory, OS-aware"""
+        if self.is_windows:
+            return str(Path.home() / ".cargo" / "bin")
+        return f"{os.environ.get('HOME', '')}/.cargo/bin"
 
     def _run_command(self, cmd: List[str], timeout: Optional[int] = None) -> Tuple[int, str, str]:
         """Run a command and return exit code, stdout, and stderr"""
@@ -113,16 +152,28 @@ class SetupManager:
                     continue
                 clean_env[k] = v
 
-            # Add Cargo to PATH
-            clean_env["PATH"] = f"{os.environ.get('HOME', '')}/.cargo/bin:{os.environ.get('PATH', '')}"
+            # Add Cargo to PATH (OS-aware separator)
+            cargo_home = self._get_cargo_home()
+            clean_env["PATH"] = f"{cargo_home}{self.path_sep}{os.environ.get('PATH', '')}"
 
-            # If executing a shell script, wrap with bash -p (privileged mode)
-            # -p tells bash to ignore BASH_ENV and ENV completely
-            # NOTE: Long options must come BEFORE short options for bash 3.2 compatibility
+            # If executing a shell script, wrap with bash
             if cmd and cmd[0].endswith('.sh'):
                 script = cmd[0]
                 args = cmd[1:]
-                cmd = ["/bin/bash", "--noprofile", "--norc", "-p", script, *args]
+                if self.is_windows:
+                    if not self._bash_path:
+                        return -1, "", (
+                            "No bash found on Windows. Install Git for Windows "
+                            "(https://git-scm.com) to get Git Bash, or install WSL."
+                        )
+                    cmd = [self._bash_path, "--noprofile", "--norc", "-p", script, *args]
+                else:
+                    # NOTE: Long options must come BEFORE short options for bash 3.2 compatibility
+                    cmd = ["/bin/bash", "--noprofile", "--norc", "-p", script, *args]
+
+            # If executing a Python script directly, prepend the interpreter
+            if cmd and cmd[0].endswith('.py'):
+                cmd = [sys.executable, *cmd]
 
             result = subprocess.run(
                 cmd,
@@ -147,7 +198,8 @@ class SetupManager:
                 if k in problematic_vars or k.startswith("BASH_FUNC_"):
                     continue
                 clean_env[k] = v
-            clean_env["PATH"] = f"{os.environ.get('HOME', '')}/.cargo/bin:{os.environ.get('PATH', '')}"
+            cargo_home = self._get_cargo_home()
+            clean_env["PATH"] = f"{cargo_home}{self.path_sep}{os.environ.get('PATH', '')}"
 
             result = subprocess.run(
                 [command, "--version"],
@@ -182,6 +234,20 @@ class SetupManager:
 
     def add_to_path(self) -> bool:
         """Add scripts directory to PATH"""
+        if self.is_windows:
+            # On Windows, add to the current session PATH only.
+            # Users should add the path to their system/user PATH via
+            # System Properties > Environment Variables if they want persistence.
+            current_path = os.environ.get("PATH", "")
+            if str(self.scripts_path) not in current_path:
+                os.environ["PATH"] = f"{self.scripts_path};{current_path}"
+                console.print(f"[green]✓[/green] Scripts directory added to current session PATH")
+            else:
+                console.print(f"[yellow]•[/yellow] Scripts directory already in PATH")
+            console.print(f"[dim]  To persist, add to your User PATH via System Environment Variables:[/dim]")
+            console.print(f"[dim]  {self.scripts_path}[/dim]")
+            return True
+
         path_export = f'export PATH="{self.scripts_path}:$PATH"'
 
         # Check if already in shell config
@@ -210,6 +276,13 @@ class SetupManager:
         """Make all scripts in the scripts directory executable"""
         if not self.scripts_path.exists():
             return 0
+
+        if self.is_windows:
+            # chmod is not meaningful on Windows
+            script_count = sum(1 for s in self.scripts_path.iterdir() if s.is_file())
+            if script_count > 0:
+                console.print(f"[green]✓[/green] Found {script_count} script(s) (chmod not needed on Windows)")
+            return script_count
 
         script_count = 0
         for script in self.scripts_path.iterdir():
@@ -288,8 +361,9 @@ class SetupManager:
             action = "Updating" if update_mode else "Installing"
             progress.update(task_id, description=f"[cyan]{action} {name}...[/cyan]")
 
-        # Make installer executable
-        installer.chmod(0o755)
+        # Make installer executable (no-op on Windows but harmless)
+        if not self.is_windows:
+            installer.chmod(0o755)
 
         # Build command with update flag if needed
         cmd = [str(installer)]
@@ -543,13 +617,21 @@ class SetupManager:
             self.show_summary()
 
             # Final message
-            console.print(Panel(
-                "[green]Setup complete![/green]\n\n"
-                "To use the changes in your current shell:\n"
-                "  [cyan]source ~/.zshrc[/cyan]\n\n"
-                "Or simply open a new terminal window.",
-                border_style="green"
-            ))
+            if self.is_windows:
+                console.print(Panel(
+                    "[green]Setup complete![/green]\n\n"
+                    "Tools have been installed via Git Bash.\n"
+                    "Open a new terminal window to use the tools.",
+                    border_style="green"
+                ))
+            else:
+                console.print(Panel(
+                    "[green]Setup complete![/green]\n\n"
+                    "To use the changes in your current shell:\n"
+                    "  [cyan]source ~/.zshrc[/cyan]\n\n"
+                    "Or simply open a new terminal window.",
+                    border_style="green"
+                ))
 
 
 def main():

--- a/src/jk_tools/cli.py
+++ b/src/jk_tools/cli.py
@@ -69,6 +69,11 @@ Examples:
         action="store_true",
         help="Show detailed output and timing for each installation step"
     )
+    parser.add_argument(
+        "--dry-run", "-n",
+        action="store_true",
+        help="Show what would be installed and check prerequisites without making changes"
+    )
 
     args = parser.parse_args()
 
@@ -80,7 +85,10 @@ Examples:
         manager.verbose = args.verbose
         if args.local_dir:
             manager.local_dir = args.local_dir
-        manager.run(update_mode=args.update)
+        if args.dry_run:
+            manager.dry_run()
+        else:
+            manager.run(update_mode=args.update)
     except KeyboardInterrupt:
         console.print("\n[yellow]Setup interrupted by user[/yellow]")
         sys.exit(1)

--- a/src/jk_tools/install/aliases.py
+++ b/src/jk_tools/install/aliases.py
@@ -8,7 +8,7 @@ Example: generate-codebase-md.sh -> gcm
 
 import os
 import sys
-import subprocess
+import shutil
 from pathlib import Path
 
 def print_status(msg):
@@ -54,11 +54,7 @@ def generate_alias(script_name):
 
 def check_command_exists(cmd):
     """Check if a command already exists in the system."""
-    try:
-        subprocess.run(['which', cmd], capture_output=True, check=True)
-        return True
-    except subprocess.CalledProcessError:
-        return False
+    return shutil.which(cmd) is not None
 
 def get_existing_aliases():
     """Read existing aliases from ~/.tools_aliases."""
@@ -131,11 +127,13 @@ def main():
     
     print_status(f"Scanning scripts in: {scripts_path}")
     
-    # Get all executable files in scripts directory
+    # Get all script files in scripts directory
     scripts = []
     for file in scripts_path.iterdir():
-        if file.is_file() and os.access(file, os.X_OK):
-            scripts.append(file)
+        if file.is_file():
+            # On Windows os.access(X_OK) is unreliable; include all script files
+            if sys.platform == "win32" or os.access(file, os.X_OK):
+                scripts.append(file)
     
     if not scripts:
         print_status("No executable scripts found")

--- a/src/jk_tools/install/claude-code.sh
+++ b/src/jk_tools/install/claude-code.sh
@@ -92,7 +92,8 @@ install_claude_code() {
 
     print_status "Setting npm prefix to $npm_prefix..."
     npm config set prefix "$npm_prefix"
-    export PATH="$npm_prefix/bin:$PATH"
+    # On Windows, npm puts binaries directly in the prefix dir (no /bin/ subdirectory)
+    export PATH="$npm_prefix/bin:$npm_prefix:$PATH"
 
     if npm install -g @anthropic-ai/claude-code; then
         print_success "Claude Code CLI installed via npm to $npm_prefix"
@@ -115,7 +116,7 @@ install_claude_code() {
         source "$HOME/.zshrc" 2>/dev/null || true
     fi
 
-    if command -v claude >/dev/null 2>&1 || [ -x "$HOME/.claude/bin/claude" ] || [ -x "$npm_prefix/bin/claude" ]; then
+    if command -v claude >/dev/null 2>&1 || [ -x "$HOME/.claude/bin/claude" ] || [ -x "$npm_prefix/bin/claude" ] || [ -x "$npm_prefix/claude" ]; then
         print_success "Claude Code CLI installation verified"
         print_status "Run 'claude login' to authenticate"
         return 0

--- a/src/jk_tools/install/codex.sh
+++ b/src/jk_tools/install/codex.sh
@@ -119,7 +119,8 @@ install_codex() {
 
         print_status "Setting npm prefix to $npm_prefix..."
         npm config set prefix "$npm_prefix"
-        export PATH="$npm_prefix/bin:$PATH"
+        # On Windows, npm puts binaries directly in the prefix dir (no /bin/ subdirectory)
+        export PATH="$npm_prefix/bin:$npm_prefix:$PATH"
 
         # Install Codex CLI
         if npm install -g @openai/codex 2>/dev/null; then
@@ -168,7 +169,7 @@ install_codex() {
 
     # Verify installation
     local npm_prefix="$HOME/.npm-global"
-    if command -v codex >/dev/null 2>&1 || [ -x "$HOME/.codex/bin/codex" ] || [ -x "$npm_prefix/bin/codex" ]; then
+    if command -v codex >/dev/null 2>&1 || [ -x "$HOME/.codex/bin/codex" ] || [ -x "$npm_prefix/bin/codex" ] || [ -x "$npm_prefix/codex" ]; then
         print_success "Codex CLI installation verified"
         print_status "Run 'codex' to start and authenticate with ChatGPT plan or API key"
         return 0

--- a/src/jk_tools/install/coding_tools_installer.py
+++ b/src/jk_tools/install/coding_tools_installer.py
@@ -452,6 +452,18 @@ Examples:
         help="Update already installed tools to latest versions"
     )
 
+    parser.add_argument(
+        "--verbose", "-v",
+        action="store_true",
+        help="Show detailed output during installation"
+    )
+
+    parser.add_argument(
+        "--no-auto-sudo",
+        action="store_true",
+        help="Disable automatic sudo retry on permission errors"
+    )
+
     args = parser.parse_args()
 
     try:

--- a/src/jk_tools/install/rust.sh
+++ b/src/jk_tools/install/rust.sh
@@ -140,6 +140,12 @@ install_prerequisites() {
                 read -r
             fi
             ;;
+        MINGW*|MSYS*|CYGWIN*)
+            # Windows (Git Bash / MSYS2 / Cygwin)
+            # rustup handles Windows build tools automatically
+            print_status "Windows detected via Git Bash - skipping prerequisite installation"
+            print_status "rustup will configure the appropriate toolchain"
+            ;;
         *)
             print_error "Unsupported OS: $os_type"
             exit 1

--- a/src/jk_tools/installers.py
+++ b/src/jk_tools/installers.py
@@ -147,8 +147,11 @@ class ToolInstaller:
                         "Download and run rustup installer", "cargo")
 
     def _preflight_code2prompt(self):
-        return self._pf("code2prompt", "Code-to-LLM-prompt converter",
-                        ["cargo"], "cargo install code2prompt", "code2prompt")
+        prereqs = ["cargo"]
+        if self.is_windows:
+            prereqs.append("link")  # MSVC linker
+        return self._pf("code2prompt", "Code-to-LLM-prompt converter (compiled from source)",
+                        prereqs, "cargo install code2prompt", "code2prompt")
 
     def _preflight_fs2(self):
         return self._pf("fs2", "FlowSpace code intelligence + MCP server",
@@ -373,6 +376,16 @@ class ToolInstaller:
                 return False, "cargo not found — install Rust first", "", "cargo not found"
 
             rc, out, err = self._run(["cargo", "install", "code2prompt"], timeout=600)
+
+            # Detect missing MSVC linker on Windows
+            if rc != 0 and self.is_windows and "link.exe" in err:
+                return False, (
+                    "cargo compile failed: MSVC linker (link.exe) not found. "
+                    "Install 'Build Tools for Visual Studio' from "
+                    "https://visualstudio.microsoft.com/visual-cpp-build-tools/ "
+                    "or run: rustup default stable-x86_64-pc-windows-gnu"
+                ), out, err
+
             if self._check_command("code2prompt"):
                 ver = self._get_version("code2prompt") or ""
                 return True, f"Successfully installed code2prompt {ver}", out, err
@@ -699,10 +712,12 @@ class ToolInstaller:
         perplexity_model = env_vars.get("PERPLEXITY_MODEL", "sonar")
         openrouter_key = env_vars.get("MCP_LLM_OPENROUTER_API_KEY", "")
 
-        # Check perplexity requirement
+        # Check perplexity — warn and disable if key is missing, don't fail
         servers_text = mcp_source.read_text(encoding="utf-8")
+        skip_perplexity = False
         if '"perplexity"' in servers_text and '"enabled": true' in servers_text:
             if not perplexity_key or perplexity_key == "your_perplexity_api_key_here":
+                skip_perplexity = True
                 env_file = self.home / ".jk-tools.env"
                 if not env_file.exists():
                     env_file.write_text(
@@ -712,10 +727,6 @@ class ToolInstaller:
                         "# MCP_LLM_OPENROUTER_API_KEY=your_key_here\n",
                         encoding="utf-8",
                     )
-                return False, (
-                    f"Perplexity MCP server is enabled but PERPLEXITY_API_KEY is not set.\n"
-                    f"Edit {env_file} and add your API key, or disable Perplexity in servers.json."
-                )
 
         # Substitute env vars
         if openrouter_key:
@@ -770,6 +781,8 @@ class ToolInstaller:
             if not isinstance(config, dict):
                 continue
             if name.startswith("_") or not config.get("enabled", True):
+                continue
+            if skip_perplexity and name == "perplexity":
                 continue
 
             server_type = self._normalize_type(config.get("type")) or "local"
@@ -852,7 +865,10 @@ class ToolInstaller:
         self._backup(codex_global_path)
         self._write_toml(codex_global_path, codex_cfg)
 
-        return True, "MCP configuration updated"
+        msg = "MCP configuration updated"
+        if skip_perplexity:
+            msg += " (Perplexity skipped — set PERPLEXITY_API_KEY in ~/.jk-tools.env to enable)"
+        return True, msg
 
     def _install_local_commands(
         self, cli_list: str, target_dir: str, v2_source: Path,

--- a/src/jk_tools/installers.py
+++ b/src/jk_tools/installers.py
@@ -1,0 +1,987 @@
+"""
+Cross-platform tool installers for jk-tools.
+
+RATIONALE FOR THIS MODULE
+=========================
+The original installer architecture used individual bash scripts (.sh files)
+orchestrated by a Python setup_manager.py. This created three layers of
+indirection: Python → bash → actual tool commands (npm, cargo, curl, etc.).
+
+This was fundamentally broken on Windows and fragile everywhere:
+- Windows has no /bin/bash; Git Bash or WSL shims were required
+- Each .sh script was essentially a one-liner wrapped in 200 lines of
+  boilerplate (OS detection, error handling, PATH management)
+- The actual tool commands (npm install, cargo install, curl, etc.) are
+  ALREADY cross-platform — the bash wrapper added nothing but pain
+
+This module replaces ALL bash installer scripts with pure Python functions.
+Each installer calls subprocess.run() directly with the real tool commands.
+No shell dependency. Works natively on Windows, macOS, and Linux.
+
+The .sh files are retained in install/ for anyone running them standalone,
+but setup_manager.py no longer invokes them.
+"""
+
+import json
+import os
+import platform
+import re
+import shutil
+import subprocess
+import sys
+import time
+import urllib.request
+import urllib.error
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+try:
+    import tomllib  # Python 3.11+
+    _load_toml = tomllib.loads
+except ModuleNotFoundError:
+    try:
+        import tomli  # type: ignore
+        _load_toml = tomli.loads
+    except ModuleNotFoundError:
+        _load_toml = None
+
+try:
+    import tomli_w  # type: ignore
+    _dump_toml = tomli_w.dumps
+except ModuleNotFoundError:
+    try:
+        import toml  # type: ignore
+        _dump_toml = toml.dumps
+    except ModuleNotFoundError:
+        _dump_toml = None
+
+
+# ---------------------------------------------------------------------------
+# InstallResult (shared with setup_manager)
+# ---------------------------------------------------------------------------
+from dataclasses import dataclass
+
+
+@dataclass
+class InstallResult:
+    """Result of an installation attempt."""
+    name: str
+    success: bool
+    message: str
+    output: str
+    error: str
+    duration: float
+    version_before: Optional[str] = None
+    version_after: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# ToolInstaller
+# ---------------------------------------------------------------------------
+
+class ToolInstaller:
+    """Cross-platform installer for developer tools.
+
+    Each ``install_*`` method installs one tool and returns an InstallResult.
+    No bash dependency — all commands are invoked directly via subprocess.
+    """
+
+    def __init__(self, resource_root: Path, *, verbose: bool = False):
+        self.resource_root = resource_root
+        self.verbose = verbose
+        self.is_windows = platform.system() == "Windows"
+        self.is_macos = platform.system() == "Darwin"
+        self.path_sep = ";" if self.is_windows else ":"
+        self.home = Path.home()
+
+    # ------------------------------------------------------------------
+    # Dry-run / preflight
+    # ------------------------------------------------------------------
+
+    def preflight(self) -> List[dict]:
+        """Return a preflight report for every install step.
+
+        Each entry is a dict with keys:
+            name, description, status ('ready', 'skip', 'missing_prereq'),
+            prereqs (list of {name, found}), action (what would happen)
+        """
+        steps = [
+            self._preflight_just(),
+            self._preflight_rust(),
+            self._preflight_code2prompt(),
+            self._preflight_fs2(),
+            self._preflight_agents(),
+            self._preflight_claude_code(),
+            self._preflight_codex(),
+            self._preflight_copilot_cli(),
+            self._preflight_aliases(),
+        ]
+        return steps
+
+    def _pf(self, name, desc, prereqs, action, installed_check=None):
+        """Build a single preflight entry."""
+        found = {p: self._check_command(p) for p in prereqs}
+        already = bool(installed_check and self._check_command(installed_check))
+        if already:
+            ver = self._get_version(installed_check) or "unknown"
+            return dict(name=name, description=desc,
+                        status="skip", reason=f"Already installed ({ver})",
+                        prereqs=[{"name": k, "found": v} for k, v in found.items()],
+                        action="No action needed")
+        all_ok = all(found.values()) if found else True
+        return dict(name=name, description=desc,
+                    status="ready" if all_ok else "missing_prereq",
+                    reason="" if all_ok else f"Missing: {', '.join(k for k,v in found.items() if not v)}",
+                    prereqs=[{"name": k, "found": v} for k, v in found.items()],
+                    action=action if all_ok else f"BLOCKED — {action}")
+
+    def _preflight_just(self):
+        return self._pf("just", "Command runner (alternative to make)",
+                        ["curl"] if not self.is_windows else [],
+                        "Download binary from just.systems", "just")
+
+    def _preflight_rust(self):
+        return self._pf("rust", "Rust toolchain (rustc, cargo, rustup)",
+                        ["curl"] if not self.is_windows else [],
+                        "Download and run rustup installer", "cargo")
+
+    def _preflight_code2prompt(self):
+        return self._pf("code2prompt", "Code-to-LLM-prompt converter",
+                        ["cargo"], "cargo install code2prompt", "code2prompt")
+
+    def _preflight_fs2(self):
+        return self._pf("fs2", "FlowSpace code intelligence + MCP server",
+                        ["uvx"], "uvx install from git+flow_squared", "fs2")
+
+    def _preflight_agents(self):
+        v2 = self.resource_root / "agents" / "v2-commands"
+        mcp = self.resource_root / "agents" / "mcp" / "servers.json"
+        prereqs_ok = v2.is_dir() and mcp.is_file()
+        return dict(name="agents", description="MCP configs + agent command files",
+                    status="ready" if prereqs_ok else "missing_prereq",
+                    reason="" if prereqs_ok else "Missing agents/v2-commands or servers.json",
+                    prereqs=[{"name": "agents/v2-commands/", "found": v2.is_dir()},
+                             {"name": "agents/mcp/servers.json", "found": mcp.is_file()}],
+                    action="Copy v2-commands to CLI dirs, generate MCP configs")
+
+    def _preflight_claude_code(self):
+        return self._pf("claude-code", "Anthropic Claude Code CLI",
+                        ["npm"], "npm install -g @anthropic-ai/claude-code", "claude")
+
+    def _preflight_codex(self):
+        return self._pf("codex", "OpenAI Codex CLI",
+                        ["npm"], "npm install -g @openai/codex", "codex")
+
+    def _preflight_copilot_cli(self):
+        return self._pf("copilot-cli", "GitHub Copilot CLI",
+                        ["npm"], "npm install -g @githubnext/github-copilot-cli", "copilot")
+
+    def _preflight_aliases(self):
+        scripts = self.resource_root / "scripts"
+        return dict(name="aliases", description="Shell aliases for scripts/",
+                    status="ready" if scripts.is_dir() else "skip",
+                    reason="" if scripts.is_dir() else "No scripts/ directory",
+                    prereqs=[], action="Generate ~/.tools_aliases")
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _run(
+        self,
+        cmd: List[str],
+        timeout: int = 300,
+        env: Optional[Dict[str, str]] = None,
+    ) -> Tuple[int, str, str]:
+        """Run a command, return (returncode, stdout, stderr)."""
+        run_env = os.environ.copy()
+        if env:
+            run_env.update(env)
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                env=run_env,
+            )
+            return result.returncode, result.stdout, result.stderr
+        except FileNotFoundError:
+            return -1, "", f"Command not found: {cmd[0]}"
+        except subprocess.TimeoutExpired:
+            return -1, "", "Command timed out"
+        except Exception as exc:
+            return -1, "", str(exc)
+
+    def _check_command(self, name: str) -> bool:
+        """Return True if *name* is on PATH."""
+        return shutil.which(name) is not None
+
+    def _get_version(self, command: str) -> Optional[str]:
+        """Run ``command --version`` and return the first line, or None."""
+        try:
+            r = subprocess.run(
+                [command, "--version"],
+                capture_output=True, text=True, timeout=10,
+            )
+            if r.returncode == 0:
+                ver = r.stdout.strip().split("\n")[0].strip()
+                if command == "codex" and ver.startswith("codex-cli "):
+                    return ver.replace("codex-cli ", "")
+                if command == "claude" and " (Claude Code)" in ver:
+                    return ver.replace(" (Claude Code)", "")
+                return ver
+        except Exception:
+            pass
+        return None
+
+    def _npm_prefix(self) -> Path:
+        """Return (and create) the user-local npm prefix directory."""
+        prefix = self.home / ".npm-global"
+        prefix.mkdir(parents=True, exist_ok=True)
+        return prefix
+
+    def _ensure_npm_path(self) -> None:
+        """Add the npm prefix to the current process PATH."""
+        prefix = self._npm_prefix()
+        # On Windows npm puts binaries directly in the prefix dir
+        dirs_to_add = [str(prefix / "bin"), str(prefix)] if self.is_windows else [str(prefix / "bin")]
+        current = os.environ.get("PATH", "")
+        for d in dirs_to_add:
+            if d not in current:
+                os.environ["PATH"] = d + self.path_sep + os.environ.get("PATH", "")
+
+    def _npm_install(self, package: str) -> Tuple[int, str, str]:
+        """Run ``npm install -g <package>`` with user-local prefix."""
+        prefix = self._npm_prefix()
+        # Set prefix
+        self._run(["npm", "config", "set", "prefix", str(prefix)], timeout=30)
+        self._ensure_npm_path()
+        return self._run(["npm", "install", "-g", package], timeout=120)
+
+    def _ensure_cargo_path(self) -> None:
+        """Add ~/.cargo/bin to PATH if not already there."""
+        cargo_bin = str(self.home / ".cargo" / "bin")
+        if cargo_bin not in os.environ.get("PATH", ""):
+            os.environ["PATH"] = cargo_bin + self.path_sep + os.environ.get("PATH", "")
+
+    def _timed(self, name: str, fn) -> InstallResult:
+        """Run *fn*, capture timing, return InstallResult."""
+        start = time.time()
+        try:
+            success, message, output, error = fn()
+        except Exception as exc:
+            success, message, output, error = False, str(exc), "", str(exc)
+        return InstallResult(
+            name=name,
+            success=success,
+            message=message,
+            output=output,
+            error=error,
+            duration=time.time() - start,
+        )
+
+    # ------------------------------------------------------------------
+    # Simple installers
+    # ------------------------------------------------------------------
+
+    def install_just(self) -> InstallResult:
+        """Install *just* command runner."""
+        def _do():
+            if self._check_command("just"):
+                ver = self._get_version("just") or "unknown"
+                return True, f"just already installed ({ver})", "", ""
+
+            local_bin = self.home / ".local" / "bin"
+            local_bin.mkdir(parents=True, exist_ok=True)
+
+            if self.is_windows:
+                # Use PowerShell to download and extract
+                url = "https://just.systems/install.sh"
+                rc, out, err = self._run(
+                    ["powershell", "-Command",
+                     f"iwr -useb {url} | & {{ $input | bash -s -- --to '{local_bin}' }}"],
+                    timeout=60,
+                )
+                # Fallback: try cargo
+                if rc != 0 and self._check_command("cargo"):
+                    rc, out, err = self._run(["cargo", "install", "just"], timeout=300)
+            else:
+                # Unix: curl | bash
+                rc, out, err = self._run(
+                    ["bash", "-c",
+                     f"curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to {local_bin}"],
+                    timeout=60,
+                )
+
+            # Add to PATH
+            bin_str = str(local_bin)
+            if bin_str not in os.environ.get("PATH", ""):
+                os.environ["PATH"] = bin_str + self.path_sep + os.environ.get("PATH", "")
+
+            if self._check_command("just"):
+                ver = self._get_version("just") or ""
+                return True, f"Successfully installed just {ver}", out, err
+            return rc == 0, "just installed (verify PATH)" if rc == 0 else f"Failed to install just", out, err
+
+        return self._timed("just", _do)
+
+    def install_rust(self) -> InstallResult:
+        """Install Rust via rustup."""
+        def _do():
+            self._ensure_cargo_path()
+            if self._check_command("cargo") and self._check_command("rustc"):
+                ver = self._get_version("rustc") or "unknown"
+                return True, f"Rust already installed ({ver})", "", ""
+
+            if self.is_windows:
+                # On Windows, download rustup-init.exe
+                rustup_init = self.home / "rustup-init.exe"
+                try:
+                    urllib.request.urlretrieve(
+                        "https://win.rustup.rs/x86_64", str(rustup_init)
+                    )
+                except Exception as exc:
+                    return False, f"Failed to download rustup: {exc}", "", str(exc)
+                rc, out, err = self._run([str(rustup_init), "-y", "--default-toolchain", "stable"], timeout=600)
+                rustup_init.unlink(missing_ok=True)
+            else:
+                rc, out, err = self._run(
+                    ["bash", "-c",
+                     "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y"],
+                    timeout=600,
+                )
+
+            self._ensure_cargo_path()
+            if self._check_command("cargo"):
+                ver = self._get_version("rustc") or ""
+                return True, f"Successfully installed Rust {ver}", out, err
+            return False, "Failed to install Rust", out, err
+
+        return self._timed("rust", _do)
+
+    def install_code2prompt(self) -> InstallResult:
+        """Install code2prompt via cargo."""
+        def _do():
+            self._ensure_cargo_path()
+            if self._check_command("code2prompt"):
+                ver = self._get_version("code2prompt") or "unknown"
+                return True, f"code2prompt already installed ({ver})", "", ""
+
+            if not self._check_command("cargo"):
+                return False, "cargo not found — install Rust first", "", "cargo not found"
+
+            rc, out, err = self._run(["cargo", "install", "code2prompt"], timeout=600)
+            if self._check_command("code2prompt"):
+                ver = self._get_version("code2prompt") or ""
+                return True, f"Successfully installed code2prompt {ver}", out, err
+            return rc == 0, "Installed code2prompt" if rc == 0 else "Failed to install code2prompt", out, err
+
+        return self._timed("code2prompt", _do)
+
+    def install_claude_code(self) -> InstallResult:
+        """Install Claude Code CLI via npm."""
+        def _do():
+            self._ensure_npm_path()
+            if self._check_command("claude"):
+                ver = self._get_version("claude") or "unknown"
+                return True, f"Claude Code already installed ({ver})", "", ""
+
+            if not self._check_command("npm"):
+                return False, "npm not found — install Node.js first", "", "npm not found"
+
+            rc, out, err = self._npm_install("@anthropic-ai/claude-code")
+            self._ensure_npm_path()
+            if self._check_command("claude"):
+                ver = self._get_version("claude") or ""
+                return True, f"Successfully installed Claude Code {ver}", out, err
+            # npm install succeeded but binary not found in PATH yet
+            if rc == 0:
+                return True, "Installed Claude Code (restart shell to use)", out, err
+            return False, "Failed to install Claude Code", out, err
+
+        return self._timed("claude-code", _do)
+
+    def install_codex(self) -> InstallResult:
+        """Install OpenAI Codex CLI via npm."""
+        def _do():
+            self._ensure_npm_path()
+            if self._check_command("codex"):
+                ver = self._get_version("codex") or "unknown"
+                return True, f"Codex already installed ({ver})", "", ""
+
+            if not self._check_command("npm"):
+                return False, "npm not found — install Node.js first", "", "npm not found"
+
+            rc, out, err = self._npm_install("@openai/codex")
+            self._ensure_npm_path()
+            if self._check_command("codex"):
+                ver = self._get_version("codex") or ""
+                return True, f"Successfully installed Codex {ver}", out, err
+            if rc == 0:
+                return True, "Installed Codex (restart shell to use)", out, err
+            return False, "Failed to install Codex", out, err
+
+        return self._timed("codex", _do)
+
+    def install_copilot_cli(self) -> InstallResult:
+        """Install GitHub Copilot CLI via npm."""
+        def _do():
+            self._ensure_npm_path()
+            if self._check_command("copilot"):
+                ver = self._get_version("copilot") or "unknown"
+                return True, f"Copilot CLI already installed ({ver})", "", ""
+
+            if not self._check_command("npm"):
+                return False, "npm not found — install Node.js first", "", "npm not found"
+
+            rc, out, err = self._npm_install("@githubnext/github-copilot-cli")
+            self._ensure_npm_path()
+            if rc == 0:
+                return True, "Successfully installed Copilot CLI", out, err
+            return False, "Failed to install Copilot CLI", out, err
+
+        return self._timed("copilot-cli", _do)
+
+    def install_fs2(self) -> InstallResult:
+        """Install FlowSpace (fs2) via uvx."""
+        def _do():
+            if self._check_command("fs2"):
+                ver = self._get_version("fs2") or "unknown"
+                return True, f"fs2 already installed ({ver})", "", ""
+
+            uv_cmd = "uv"
+            if not self._check_command(uv_cmd):
+                return False, "uv not found — install uv first", "", "uv not found"
+
+            rc, out, err = self._run(
+                ["uvx", "--from", "git+https://github.com/AI-Substrate/flow_squared", "fs2", "install"],
+                timeout=120,
+            )
+            if rc == 0:
+                return True, "Successfully installed fs2", out, err
+            return False, "Failed to install fs2", out, err
+
+        return self._timed("fs2", _do)
+
+    # ------------------------------------------------------------------
+    # Aliases
+    # ------------------------------------------------------------------
+
+    def install_aliases(self) -> InstallResult:
+        """Generate convention-based aliases for scripts."""
+        def _do():
+            scripts_path = self.resource_root / "scripts"
+            if not scripts_path.exists():
+                return True, "No scripts directory found, skipping aliases", "", ""
+
+            scripts = [f for f in scripts_path.iterdir()
+                       if f.is_file() and (self.is_windows or os.access(f, os.X_OK))]
+            if not scripts:
+                return True, "No scripts found, skipping aliases", "", ""
+
+            new_aliases: Dict[str, str] = {}
+            for script_file in scripts:
+                name = script_file.stem
+                if "-" not in name:
+                    continue
+                parts = name.split("-")
+                alias = "jk-" + "".join(p[0].lower() for p in parts if p)
+                if shutil.which(alias):
+                    continue  # avoid conflicts
+                new_aliases[alias] = str(script_file.resolve())
+
+            if not new_aliases:
+                return True, "No aliases to create", "", ""
+
+            aliases_file = self.home / ".tools_aliases"
+            with open(aliases_file, "w") as f:
+                f.write("# Auto-generated aliases for tools repository\n")
+                f.write("# Generated by jk-tools installers.py\n")
+                f.write("# DO NOT EDIT - This file is auto-generated\n\n")
+                for alias, command in sorted(new_aliases.items()):
+                    f.write(f"alias {alias}='{command}'\n")
+
+            # Source in .zshrc (Unix only)
+            if not self.is_windows:
+                zshrc = self.home / ".zshrc"
+                source_line = f'[ -f "{aliases_file}" ] && source "{aliases_file}" # Tools repository aliases'
+                if zshrc.exists():
+                    content = zshrc.read_text()
+                    if str(aliases_file) not in content:
+                        with open(zshrc, "a") as f:
+                            f.write(f"\n{source_line}\n")
+
+            return True, f"Created {len(new_aliases)} alias(es)", "", ""
+
+        return self._timed("aliases", _do)
+
+    # ------------------------------------------------------------------
+    # Agents (MCP config + command file installation)
+    # ------------------------------------------------------------------
+
+    def install_agents(
+        self,
+        *,
+        clear_mcp: bool = False,
+        commands_local: str = "",
+        local_dir: str = "",
+    ) -> InstallResult:
+        """Install agent commands and MCP server configs.
+
+        This replaces agents.sh — copies v2-commands to all CLI directories
+        and generates MCP configurations from servers.json.
+        """
+        def _do():
+            repo_root = self.resource_root
+            v2_source = repo_root / "agents" / "v2-commands"
+            mcp_source = repo_root / "agents" / "mcp" / "servers.json"
+
+            # Local mode
+            if commands_local:
+                return self._install_local_commands(
+                    commands_local, local_dir or str(Path.cwd()), v2_source,
+                )
+
+            # Validate source
+            if not v2_source.is_dir():
+                return False, f"v2-commands not found: {v2_source}", "", ""
+            md_files = sorted(v2_source.glob("*.md"))
+            if not md_files:
+                return False, f"No .md files in {v2_source}", "", ""
+
+            output_lines: List[str] = []
+
+            # Target directories
+            claude_dir = self.home / ".claude" / "commands"
+            opencode_dir = self.home / ".config" / "opencode" / "command"
+            codex_dir = self.home / ".codex" / "prompts"
+            copilot_prompts = self.home / ".config" / "github-copilot" / "prompts"
+            copilot_cli_dir = Path(os.environ.get("XDG_CONFIG_HOME", str(self.home))) / ".copilot"
+            copilot_cli_agents = copilot_cli_dir / "agents"
+            copilot_cli_default = self.home / ".copilot"
+            copilot_cli_default_agents = copilot_cli_default / "agents"
+
+            if self.is_macos:
+                vscode_user_dir = self.home / "Library" / "Application Support" / "Code" / "User"
+            else:
+                vscode_user_dir = self.home / ".config" / "Code" / "User"
+            vscode_project_dir = repo_root / ".vscode"
+
+            # Create all dirs
+            for d in [claude_dir, opencode_dir, codex_dir, copilot_prompts,
+                       copilot_cli_dir, copilot_cli_agents,
+                       vscode_user_dir, vscode_project_dir]:
+                d.mkdir(parents=True, exist_ok=True)
+
+            # Clean stale plan commands
+            for d, pat in [
+                (claude_dir, "plan-[0-9]*"),
+                (opencode_dir, "plan-[0-9]*"),
+                (codex_dir, "plan-[0-9]*"),
+                (vscode_project_dir, "plan-[0-9]*"),
+                (copilot_prompts, "plan-[0-9]*.prompt.md"),
+                (copilot_cli_agents, "plan-[0-9]*"),
+            ]:
+                for stale in d.glob(pat):
+                    stale.unlink()
+
+            # Copy v2-commands to all targets
+            for md in md_files:
+                shutil.copy2(md, claude_dir / md.name)
+                shutil.copy2(md, opencode_dir / md.name)
+                shutil.copy2(md, codex_dir / md.name)
+                shutil.copy2(md, vscode_project_dir / md.name)
+                prompt_name = md.stem + ".prompt.md"
+                shutil.copy2(md, copilot_prompts / prompt_name)
+
+            output_lines.append(f"Copied {len(md_files)} command files to all targets")
+
+            # Generate Copilot CLI agent files
+            skip = {"README.md", "GETTING-STARTED.md"}
+            agent_count = 0
+            for md in md_files:
+                if md.name in skip:
+                    continue
+                self._generate_agent_md(md, copilot_cli_agents)
+                agent_count += 1
+
+            # Mirror to default location if XDG override
+            if str(copilot_cli_dir) != str(copilot_cli_default):
+                copilot_cli_default_agents.mkdir(parents=True, exist_ok=True)
+                for af in copilot_cli_agents.glob("*.agent.md"):
+                    shutil.copy2(af, copilot_cli_default_agents / af.name)
+
+            output_lines.append(f"Generated {agent_count} Copilot CLI agents")
+
+            # MCP config generation
+            if mcp_source.is_file():
+                ok, msg = self._generate_mcp_configs(
+                    mcp_source=mcp_source,
+                    repo_root=repo_root,
+                    vscode_user_config=vscode_user_dir / "mcp.json",
+                    vscode_project_config=vscode_project_dir / "mcp.json",
+                    copilot_cli_mcp=copilot_cli_dir / "mcp-config.json",
+                    clear_mcp=clear_mcp,
+                )
+                if ok:
+                    output_lines.append("MCP configuration updated")
+                else:
+                    return False, msg, "\n".join(output_lines), msg
+            else:
+                output_lines.append("No servers.json found, skipping MCP config")
+
+            return True, "Successfully installed agents", "\n".join(output_lines), ""
+
+        return self._timed("agents", _do)
+
+    def _generate_agent_md(self, source: Path, dest_dir: Path) -> None:
+        """Convert a v2-command .md file into a Copilot CLI .agent.md file."""
+        content = source.read_text(encoding="utf-8")
+        agent_name = source.stem
+        desc = f"Command: {agent_name}"
+        content_body = content
+
+        if content.startswith("---"):
+            fm = re.match(r"^---\s*\n(.*?)\n---\s*\n", content, re.DOTALL)
+            if fm:
+                for line in fm.group(1).split("\n"):
+                    if line.strip().startswith("description:"):
+                        desc = line.partition(":")[2].strip().strip("\"'")
+                        break
+                content_body = content[fm.end():]
+
+        frontmatter = (
+            f'---\nname: "{agent_name}"\n'
+            f'description: "{desc}"\n'
+            f'tools:\n  - "*"\n---\n\n'
+        )
+        dest = dest_dir / f"{source.stem}.agent.md"
+        dest.write_text(frontmatter + content_body.lstrip(), encoding="utf-8")
+
+    def _load_env_file(self) -> Dict[str, str]:
+        """Load .env key=value pairs from the first found env file."""
+        candidates = [
+            Path.cwd() / ".env",
+            self.home / ".jk-tools.env",
+            self.resource_root / ".env",
+        ]
+        for path in candidates:
+            if path.is_file():
+                result: Dict[str, str] = {}
+                for line in path.read_text(encoding="utf-8").splitlines():
+                    line = line.strip()
+                    if not line or line.startswith("#"):
+                        continue
+                    if "=" in line:
+                        k, _, v = line.partition("=")
+                        result[k.strip()] = v.strip()
+                return result
+        return {}
+
+    def _generate_mcp_configs(
+        self,
+        *,
+        mcp_source: Path,
+        repo_root: Path,
+        vscode_user_config: Path,
+        vscode_project_config: Path,
+        copilot_cli_mcp: Path,
+        clear_mcp: bool,
+    ) -> Tuple[bool, str]:
+        """Generate MCP configs for all CLIs from servers.json.
+
+        Returns (success, message).
+        """
+        env_vars = self._load_env_file()
+        perplexity_key = env_vars.get("PERPLEXITY_API_KEY", "")
+        perplexity_model = env_vars.get("PERPLEXITY_MODEL", "sonar")
+        openrouter_key = env_vars.get("MCP_LLM_OPENROUTER_API_KEY", "")
+
+        # Check perplexity requirement
+        servers_text = mcp_source.read_text(encoding="utf-8")
+        if '"perplexity"' in servers_text and '"enabled": true' in servers_text:
+            if not perplexity_key or perplexity_key == "your_perplexity_api_key_here":
+                env_file = self.home / ".jk-tools.env"
+                if not env_file.exists():
+                    env_file.write_text(
+                        "# Perplexity MCP Server Configuration\n"
+                        "PERPLEXITY_API_KEY=your_perplexity_api_key_here\n\n"
+                        "# MCP Browser Use Configuration (optional)\n"
+                        "# MCP_LLM_OPENROUTER_API_KEY=your_key_here\n",
+                        encoding="utf-8",
+                    )
+                return False, (
+                    f"Perplexity MCP server is enabled but PERPLEXITY_API_KEY is not set.\n"
+                    f"Edit {env_file} and add your API key, or disable Perplexity in servers.json."
+                )
+
+        # Substitute env vars
+        if openrouter_key:
+            servers_text = servers_text.replace("${OPENROUTER_API_KEY}", openrouter_key)
+        if perplexity_key:
+            servers_text = servers_text.replace("${PERPLEXITY_API_KEY}", perplexity_key)
+        if perplexity_model:
+            servers_text = servers_text.replace("${PERPLEXITY_MODEL}", perplexity_model)
+
+        servers = json.loads(servers_text)
+
+        # Config file paths
+        opencode_global_path = self.home / ".config" / "opencode" / "opencode.json"
+        opencode_project_path = repo_root / "opencode.json"
+        claude_global_path = self.home / ".claude.json"
+        codex_global_path = self.home / ".codex" / "config.toml"
+
+        # Ensure parent dirs
+        for p in [opencode_global_path, codex_global_path, vscode_user_config,
+                  vscode_project_config, copilot_cli_mcp]:
+            p.parent.mkdir(parents=True, exist_ok=True)
+
+        # Load existing configs
+        opencode_global = self._migrate_opencode(self._load_json(opencode_global_path))
+        opencode_project = self._migrate_opencode(self._load_json(opencode_project_path))
+        claude_cfg = self._load_json(claude_global_path)
+        codex_cfg = self._load_toml(codex_global_path)
+        vscode_user = self._load_json(vscode_user_config)
+        vscode_project = self._load_json(vscode_project_config)
+        copilot_cli_cfg = self._load_json(copilot_cli_mcp)
+
+        # Clear if requested
+        if clear_mcp:
+            opencode_global.pop("mcp", None)
+            opencode_project.pop("mcp", None)
+            claude_cfg.pop("mcpServers", None)
+            codex_cfg.pop("mcp_servers", None)
+            vscode_user.pop("mcpServers", None)
+            vscode_project.pop("mcpServers", None)
+            copilot_cli_cfg.pop("mcpServers", None)
+
+        # Get/create sections
+        oc_g_mcp = opencode_global.setdefault("mcp", {})
+        oc_p_mcp = opencode_project.setdefault("mcp", {})
+        claude_servers = claude_cfg.setdefault("mcpServers", {})
+        codex_servers = codex_cfg.setdefault("mcp_servers", {})
+        vs_u_servers = vscode_user.setdefault("mcpServers", {})
+        vs_p_servers = vscode_project.setdefault("mcpServers", {})
+        cop_servers = copilot_cli_cfg.setdefault("mcpServers", {})
+
+        for name, config in servers.items():
+            if not isinstance(config, dict):
+                continue
+            if name.startswith("_") or not config.get("enabled", True):
+                continue
+
+            server_type = self._normalize_type(config.get("type")) or "local"
+            enabled = bool(config.get("enabled", True))
+            environment = config.get("environment") or config.get("env") or {}
+            command_list = self._merge_cmd_args(config.get("command"), config.get("args"))
+            url = config.get("url")
+            headers = config.get("headers")
+
+            # OpenCode
+            oc_entry: Dict = {"type": server_type, "enabled": enabled}
+            if server_type == "remote" and url:
+                oc_entry["url"] = url
+                if headers:
+                    oc_entry["headers"] = headers
+            elif command_list:
+                oc_entry["command"] = command_list
+            if environment:
+                oc_entry["environment"] = environment
+            oc_g_mcp[name] = dict(oc_entry)
+            oc_p_mcp[name] = dict(oc_entry)
+
+            # Claude
+            claude_servers[name] = {
+                "type": "stdio",
+                "command": config.get("command"),
+                "args": config.get("args", []),
+                "env": environment if isinstance(environment, dict) else {},
+            }
+
+            # Codex
+            codex_server: Dict = {"command": config.get("command"), "args": config.get("args", [])}
+            if environment and isinstance(environment, dict):
+                codex_server["env"] = environment
+            if server_type == "remote":
+                if url:
+                    codex_server["url"] = url
+                if headers:
+                    codex_server["headers"] = headers
+            codex_servers[name] = codex_server
+
+            # VS Code
+            vs_entry: Dict = {
+                "command": config.get("command"),
+                "args": config.get("args", []),
+                "enabled": enabled,
+            }
+            if environment and isinstance(environment, dict):
+                vs_entry["env"] = environment
+            if server_type == "remote":
+                if url:
+                    vs_entry["url"] = url
+                if headers:
+                    vs_entry["headers"] = headers
+            vs_u_servers[name] = dict(vs_entry)
+            vs_p_servers[name] = dict(vs_entry)
+
+            # Copilot CLI
+            cop_servers[name] = {
+                "type": "local",
+                "command": config.get("command"),
+                "args": config.get("args", []),
+                "tools": ["*"],
+                **({"env": environment} if environment and isinstance(environment, dict) else {}),
+            }
+
+        # Backup and write
+        all_json = [
+            (opencode_global_path, opencode_global),
+            (opencode_project_path, opencode_project),
+            (claude_global_path, claude_cfg),
+            (vscode_user_config, vscode_user),
+            (vscode_project_config, vscode_project),
+            (copilot_cli_mcp, copilot_cli_cfg),
+        ]
+        for path, data in all_json:
+            self._backup(path)
+            self._write_json(path, data)
+
+        self._backup(codex_global_path)
+        self._write_toml(codex_global_path, codex_cfg)
+
+        return True, "MCP configuration updated"
+
+    def _install_local_commands(
+        self, cli_list: str, target_dir: str, v2_source: Path,
+    ) -> Tuple[bool, str, str, str]:
+        """Install commands to a local project directory."""
+        if not v2_source.is_dir():
+            return False, f"Source not found: {v2_source}", "", ""
+        md_files = sorted(v2_source.glob("*.md"))
+        if not md_files:
+            return False, "No .md files found", "", ""
+
+        output_lines: List[str] = []
+        target = Path(target_dir)
+        skip = {"README.md", "GETTING-STARTED.md"}
+
+        if "claude" in cli_list:
+            d = target / ".claude" / "commands"
+            d.mkdir(parents=True, exist_ok=True)
+            for md in md_files:
+                shutil.copy2(md, d / md.name)
+            output_lines.append(f"Claude: {len(md_files)} files → {d}")
+
+        if "opencode" in cli_list:
+            d = target / ".opencode" / "command"
+            d.mkdir(parents=True, exist_ok=True)
+            for md in md_files:
+                shutil.copy2(md, d / md.name)
+            output_lines.append(f"OpenCode: {len(md_files)} files → {d}")
+
+        if "ghcp" in cli_list:
+            d = target / ".github" / "prompts"
+            d.mkdir(parents=True, exist_ok=True)
+            for md in md_files:
+                prompt = md.stem + ".prompt.md"
+                shutil.copy2(md, d / prompt)
+            output_lines.append(f"GitHub Copilot: {len(md_files)} prompts → {d}")
+
+        if "copilot-cli" in cli_list:
+            d = target / ".github" / "agents"
+            d.mkdir(parents=True, exist_ok=True)
+            count = 0
+            for md in md_files:
+                if md.name in skip:
+                    continue
+                self._generate_agent_md(md, d)
+                count += 1
+            output_lines.append(f"Copilot CLI: {count} agents → {d}")
+
+        if "codex" in cli_list:
+            output_lines.append("Codex: local commands not supported (global only)")
+
+        return True, "Local commands installed", "\n".join(output_lines), ""
+
+    # ------------------------------------------------------------------
+    # JSON / TOML helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _load_json(path: Path) -> dict:
+        if path.exists():
+            try:
+                return json.loads(path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                backup = path.with_suffix(path.suffix + ".bak")
+                path.rename(backup)
+        return {}
+
+    @staticmethod
+    def _write_json(path: Path, data: dict) -> None:
+        path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+    @staticmethod
+    def _load_toml(path: Path) -> dict:
+        if _load_toml and path.exists():
+            try:
+                return _load_toml(path.read_text(encoding="utf-8"))
+            except Exception:
+                backup = path.with_suffix(path.suffix + ".bak")
+                path.rename(backup)
+        return {}
+
+    @staticmethod
+    def _write_toml(path: Path, data: dict) -> None:
+        if _dump_toml:
+            path.write_text(_dump_toml(data), encoding="utf-8")
+
+    @staticmethod
+    def _backup(path: Path) -> None:
+        if path.exists():
+            ts = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+            shutil.copy2(path, path.with_suffix(f"{path.suffix}.backup-{ts}"))
+
+    @staticmethod
+    def _normalize_type(value) -> Optional[str]:
+        mapping = {"stdio": "local", "sse": "remote"}
+        if isinstance(value, str):
+            return mapping.get(value, value)
+        return None
+
+    @staticmethod
+    def _merge_cmd_args(command, args) -> list:
+        cmd_list = [command] if isinstance(command, str) else (list(command) if command else [])
+        if isinstance(args, (list, tuple)):
+            cmd_list.extend(str(a) for a in args)
+        elif isinstance(args, str):
+            cmd_list.append(args)
+        return cmd_list
+
+    @staticmethod
+    def _migrate_opencode(data: dict) -> dict:
+        if not isinstance(data, dict):
+            data = {}
+        data.setdefault("$schema", "https://opencode.ai/config.json")
+        mcp = data.setdefault("mcp", {})
+        legacy = data.pop("mcpServers", {})
+        if isinstance(legacy, dict):
+            for name, entry in legacy.items():
+                if not isinstance(entry, dict):
+                    continue
+                new: Dict = {"type": ToolInstaller._normalize_type(entry.get("type")) or "local"}
+                env = entry.get("environment") or entry.get("env")
+                if env:
+                    new["environment"] = env
+                if new["type"] == "remote":
+                    if entry.get("url"):
+                        new["url"] = entry["url"]
+                else:
+                    cmd = ToolInstaller._merge_cmd_args(entry.get("command"), entry.get("args"))
+                    if cmd:
+                        new["command"] = cmd
+                mcp.setdefault(name, {}).update(new)
+        return data

--- a/src/jk_tools/installers.py
+++ b/src/jk_tools/installers.py
@@ -142,16 +142,21 @@ class ToolInstaller:
                         "Download binary from just.systems", "just")
 
     def _preflight_rust(self):
-        return self._pf("rust", "Rust toolchain (rustc, cargo, rustup)",
-                        ["curl"] if not self.is_windows else [],
+        prereqs = ["curl"] if not self.is_windows else []
+        desc = "Rust toolchain (rustc, cargo, rustup)"
+        if self.is_windows and not self._check_command("link"):
+            desc += " + MSVC build tools (auto-installed via winget)"
+        return self._pf("rust", desc, prereqs,
                         "Download and run rustup installer", "cargo")
 
     def _preflight_code2prompt(self):
         prereqs = ["cargo"]
-        if self.is_windows:
-            prereqs.append("link")  # MSVC linker
-        return self._pf("code2prompt", "Code-to-LLM-prompt converter (compiled from source)",
-                        prereqs, "cargo install code2prompt", "code2prompt")
+        desc = "Code-to-LLM-prompt converter (compiled from source)"
+        if self.is_windows and not self._check_command("link"):
+            prereqs.append("link")
+            desc += " — needs MSVC build tools (installed with rust step)"
+        return self._pf("code2prompt", desc, prereqs,
+                        "cargo install code2prompt", "code2prompt")
 
     def _preflight_fs2(self):
         return self._pf("fs2", "FlowSpace code intelligence + MCP server",
@@ -269,6 +274,27 @@ class ToolInstaller:
         if cargo_bin not in os.environ.get("PATH", ""):
             os.environ["PATH"] = cargo_bin + self.path_sep + os.environ.get("PATH", "")
 
+    def _install_msvc_build_tools(self) -> None:
+        """Install MSVC C++ build tools via winget (Windows only).
+
+        Required for ``cargo install`` to compile native code on Windows.
+        Uses ``winget`` which is pre-installed on Windows 10 1709+ and all
+        Windows 11 machines.
+        """
+        if not self._check_command("winget"):
+            return  # winget not available; install_code2prompt will report the error
+
+        self._run(
+            [
+                "winget", "install",
+                "--id", "Microsoft.VisualStudio.2022.BuildTools",
+                "-e", "--silent",
+                "--override",
+                "--wait --quiet --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended",
+            ],
+            timeout=600,
+        )
+
     def _timed(self, name: str, fn) -> InstallResult:
         """Run *fn*, capture timing, return InstallResult."""
         start = time.time()
@@ -331,9 +357,14 @@ class ToolInstaller:
         return self._timed("just", _do)
 
     def install_rust(self) -> InstallResult:
-        """Install Rust via rustup."""
+        """Install Rust via rustup (and MSVC build tools on Windows)."""
         def _do():
             self._ensure_cargo_path()
+
+            # On Windows, ensure MSVC build tools are present (needed by cargo)
+            if self.is_windows and not self._check_command("link"):
+                self._install_msvc_build_tools()
+
             if self._check_command("cargo") and self._check_command("rustc"):
                 ver = self._get_version("rustc") or "unknown"
                 return True, f"Rust already installed ({ver})", "", ""

--- a/src/jk_tools/setup_manager.py
+++ b/src/jk_tools/setup_manager.py
@@ -1,18 +1,18 @@
 #!/usr/bin/env python3
 """
 Tools Repository Setup Manager
-An elegant Python-based setup system with rich terminal output
+An elegant Python-based setup system with rich terminal output.
+
+Uses ToolInstaller from installers.py for all tool installations —
+no bash dependency.
 """
 
 import os
 import sys
-import subprocess
 import platform
-import shutil
 import time
 from pathlib import Path
-from typing import List, Tuple, Optional
-from dataclasses import dataclass
+from typing import Callable, List, Optional, Tuple
 
 from rich.console import Console
 from rich.progress import (
@@ -25,43 +25,20 @@ from rich.progress import (
 )
 from rich.table import Table
 from rich.panel import Panel
-from rich.layout import Layout
-from rich.live import Live
 from rich.text import Text
 from rich import box
-from rich.syntax import Syntax
+
+from jk_tools.installers import ToolInstaller, InstallResult
 
 console = Console()
-
-@dataclass
-class InstallResult:
-    """Result of an installation attempt"""
-    name: str
-    success: bool
-    message: str
-    output: str
-    error: str
-    duration: float
-    version_before: Optional[str] = None
-    version_after: Optional[str] = None
-
 
 class SetupManager:
     """Manages the setup process for the tools repository"""
 
     def __init__(self, resource_root: Optional[Path] = None):
-        """
-        Initialize SetupManager
-
-        Args:
-            resource_root: Optional path to tools repository for dev mode.
-                          If None, uses package installation location.
-        """
         if resource_root:
-            # Dev mode: use provided local filesystem path
             self.script_dir = resource_root.resolve()
         else:
-            # Normal mode: use package installation location
             self.script_dir = Path(__file__).parent.resolve()
 
         self.scripts_path = self.script_dir / "scripts"
@@ -73,16 +50,14 @@ class SetupManager:
         self.shell_config = Path.home() / ".zshrc"
         self.results: List[InstallResult] = []
 
-        # Optional flags (set by main())
+        # Optional flags (set by cli.py)
         self.clear_mcp = False
         self.commands_local = ""
         self.local_dir = str(Path.cwd())
         self.verbose = False
 
-        # Cache bash path on Windows
-        self._bash_path: Optional[str] = None
-        if self.is_windows:
-            self._bash_path = self._find_bash()
+        # Cross-platform tool installer — no bash needed
+        self.installer = ToolInstaller(self.script_dir, verbose=self.verbose)
 
     def _detect_os(self) -> str:
         """Detect the operating system"""
@@ -95,127 +70,6 @@ class SetupManager:
             return "Windows"
         else:
             return "Unknown"
-
-    def _find_bash(self) -> Optional[str]:
-        """Find a usable bash executable on Windows"""
-        # Prefer Git Bash as it handles Windows paths natively
-        git_bash_paths = [
-            r"C:\Program Files\Git\bin\bash.exe",
-            r"C:\Program Files (x86)\Git\bin\bash.exe",
-        ]
-        for p in git_bash_paths:
-            if os.path.isfile(p):
-                return p
-
-        # Fall back to any bash on PATH (e.g. WSL bash)
-        bash = shutil.which("bash")
-        if bash:
-            return bash
-
-        return None
-
-    def _get_cargo_home(self) -> str:
-        """Get the Cargo home directory, OS-aware"""
-        if self.is_windows:
-            return str(Path.home() / ".cargo" / "bin")
-        return f"{os.environ.get('HOME', '')}/.cargo/bin"
-
-    def _run_command(self, cmd: List[str], timeout: Optional[int] = None) -> Tuple[int, str, str]:
-        """Run a command and return exit code, stdout, and stderr"""
-        try:
-            # Create clean environment to prevent BASH_ENV and other startup file interference
-            # Remove BASH_ENV and ENV entirely, AND use bash -p (privileged mode)
-            # See: https://www.gnu.org/software/bash/manual/bash.html
-
-            # Filter out problematic environment variables that could interfere with bash
-            # This includes both bash-specific and zsh-specific variables
-            problematic_vars = {
-                "BASH_ENV",      # Bash startup file for non-interactive shells
-                "ENV",           # POSIX shell startup file
-                "PROMPT_COMMAND",# Sometimes abused to run code before prompts
-                "CDPATH",        # Causes cd to search multiple directories
-                "BASH_FUNC_*",   # Exported bash functions (shellshock-related)
-                "ZDOTDIR",       # Zsh config directory (shouldn't affect bash, but be safe)
-            }
-
-            clean_env = {}
-            for k, v in os.environ.items():
-                # Skip problematic variables and bash function exports
-                if k in problematic_vars or k.startswith("BASH_FUNC_"):
-                    continue
-                clean_env[k] = v
-
-            # Add Cargo to PATH (OS-aware separator)
-            cargo_home = self._get_cargo_home()
-            clean_env["PATH"] = f"{cargo_home}{self.path_sep}{os.environ.get('PATH', '')}"
-
-            # If executing a shell script, wrap with bash
-            if cmd and cmd[0].endswith('.sh'):
-                script = cmd[0]
-                args = cmd[1:]
-                if self.is_windows:
-                    if not self._bash_path:
-                        return -1, "", (
-                            "No bash found on Windows. Install Git for Windows "
-                            "(https://git-scm.com) to get Git Bash, or install WSL."
-                        )
-                    cmd = [self._bash_path, "--noprofile", "--norc", "-p", script, *args]
-                else:
-                    # NOTE: Long options must come BEFORE short options for bash 3.2 compatibility
-                    cmd = ["/bin/bash", "--noprofile", "--norc", "-p", script, *args]
-
-            # If executing a Python script directly, prepend the interpreter
-            if cmd and cmd[0].endswith('.py'):
-                cmd = [sys.executable, *cmd]
-
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=timeout,
-                env=clean_env
-            )
-            return result.returncode, result.stdout, result.stderr
-        except subprocess.TimeoutExpired:
-            return -1, "", "Command timed out"
-        except Exception as e:
-            return -1, "", str(e)
-
-    def _get_version(self, command: str) -> Optional[str]:
-        """Get version from a command, handling different output formats"""
-        try:
-            # Use clean environment (same as _run_command)
-            problematic_vars = {"BASH_ENV", "ENV", "PROMPT_COMMAND", "CDPATH", "ZDOTDIR"}
-            clean_env = {}
-            for k, v in os.environ.items():
-                if k in problematic_vars or k.startswith("BASH_FUNC_"):
-                    continue
-                clean_env[k] = v
-            clean_env["PATH"] = f"{self._get_cargo_home()}{self.path_sep}{os.environ.get('PATH', '')}"
-
-            result = subprocess.run(
-                [command, "--version"],
-                capture_output=True,
-                text=True,
-                timeout=10,
-                env=clean_env
-            )
-            if result.returncode == 0:
-                # Clean up version output - remove extra whitespace and normalize
-                version = result.stdout.strip().split('\n')[0].strip()
-                # Handle different formats:
-                # "codex-cli 0.44.0" -> "0.44.0"
-                # "2.0.8 (Claude Code)" -> "2.0.8"
-                # "0.14.1" -> "0.14.1"
-                if command == "codex" and version.startswith("codex-cli "):
-                    return version.replace("codex-cli ", "")
-                elif command == "claude" and " (Claude Code)" in version:
-                    return version.replace(" (Claude Code)", "")
-                else:
-                    return version
-        except (subprocess.TimeoutExpired, subprocess.SubprocessError, FileNotFoundError):
-            pass
-        return None
 
     def check_prerequisites(self) -> bool:
         """Check if prerequisites are met"""
@@ -287,162 +141,64 @@ class SetupManager:
 
         return script_count
 
-    def get_installers(self) -> List[Path]:
-        """Get list of installer scripts in the correct order"""
-        # TODO: Phase 2+ - Replace bash script installers with Python CodingToolsInstaller
-        # from install.coding_tools_installer import CodingToolsInstaller
-        # installer = CodingToolsInstaller(console=console, update_mode=update_mode)
-        # installer.run()
-
-        if not self.install_path.exists():
-            return []
-
-        # Specified order for dependencies
-        install_order = [
-            "just.sh",
-            "rust.sh",
-            "code2prompt.sh",
-            "fs2.sh",       # FlowSpace - install before agents.sh (MCP server depends on it)
-            "agents.sh",
-            # "opencode.sh",  # Commented out - OpenCode installation disabled
-            "claude-code.sh",
-            "codex.sh",
-            "copilot-cli.sh",  # GitHub Copilot CLI
-            "aliases.py"
+    def get_install_steps(self) -> List[Tuple[str, Callable[[], InstallResult]]]:
+        """Return ordered list of (name, installer_function) tuples."""
+        i = self.installer
+        steps = [
+            ("just", i.install_just),
+            ("rust", i.install_rust),
+            ("code2prompt", i.install_code2prompt),
+            ("fs2", i.install_fs2),
+            ("agents", lambda: i.install_agents(
+                clear_mcp=self.clear_mcp,
+                commands_local=self.commands_local,
+                local_dir=self.local_dir,
+            )),
+            ("claude-code", i.install_claude_code),
+            ("codex", i.install_codex),
+            ("copilot-cli", i.install_copilot_cli),
+            ("aliases", i.install_aliases),
         ]
+        return steps
 
-        installers = []
+    def run_install_step(
+        self,
+        name: str,
+        fn: Callable[[], InstallResult],
+        progress: Optional[Progress] = None,
+        task_id: Optional[int] = None,
+    ) -> InstallResult:
+        """Run a single install step and update progress."""
+        if progress and task_id is not None:
+            progress.update(task_id, description=f"[cyan]Installing {name}...[/cyan]")
 
-        # Explicitly disabled installers
-        # - opencode.sh: OpenCode installation disabled
-        # - install-coding-stuff.sh: Redundant - same tools installed by individual scripts
-        #   (claude-code.sh, codex.sh). Also hangs on some systems at opencode.ai installer.
-        disabled_installers = ["opencode.sh", "install-coding-stuff.sh"]
-
-        # Add installers in specified order first
-        for name in install_order:
-            installer = self.install_path / name
-            if installer.exists():
-                installers.append(installer)
-
-        # Add any remaining installers (excluding disabled ones)
-        for installer in self.install_path.iterdir():
-            if installer.suffix in ['.sh', '.py'] and installer not in installers and installer.name not in disabled_installers:
-                installers.append(installer)
-
-        return installers
-
-    def run_installer(self, installer: Path, progress: Optional[Progress] = None, task_id: Optional[int] = None, update_mode: bool = False) -> InstallResult:
-        """Run a single installer script"""
-        name = installer.stem
-        start_time = time.time()
-
-        # Get version before installation for version-tracked tools
-        version_before = None
-        if name in ["codex", "claude-code"]:  # Removed opencode
-            if name == "codex":
-                version_before = self._get_version("codex")
-            elif name == "claude-code":
-                version_before = self._get_version("claude")
-            # elif name == "opencode":  # Commented out - OpenCode disabled
-            #     version_before = self._get_version("opencode")
+        result = fn()
 
         if progress and task_id is not None:
-            action = "Updating" if update_mode else "Installing"
-            progress.update(task_id, description=f"[cyan]{action} {name}...[/cyan]")
-
-        # Make installer executable (no-op on Windows)
-        if not self.is_windows:
-            installer.chmod(0o755)
-
-        # Build command with update flag if needed
-        cmd = [str(installer)]
-        if update_mode:
-            # Add update flag for installers that support it
-            updatable_installers = ["claude-code", "codex", "copilot-cli", "install-coding-stuff"]  # Removed opencode
-            if name in updatable_installers:
-                cmd.append("--update")
-
-        # Add --clear-mcp flag for agents installer if requested
-        if name == "agents" and hasattr(self, 'clear_mcp') and self.clear_mcp:
-            cmd.append("--clear-mcp")
-
-        # Pass the current Python interpreter to agents.sh so it uses the uvx environment
-        if name == "agents":
-            cmd.extend(["--python", sys.executable])
-
-        # Add --commands-local flags for agents installer if requested
-        if name == "agents" and hasattr(self, 'commands_local') and self.commands_local:
-            cmd.extend(["--commands-local", self.commands_local])
-            if hasattr(self, 'local_dir'):
-                cmd.extend(["--local-dir", self.local_dir])
-
-        # Add --no-auto-sudo flag if requested (for all installers)
-        if hasattr(self, 'no_auto_sudo') and self.no_auto_sudo:
-            cmd.append("--no-auto-sudo")
-
-        # Add --verbose flag if requested (for all installers that support it)
-        if hasattr(self, 'verbose') and self.verbose:
-            cmd.append("--verbose")
-
-        # Run the installer
-        returncode, stdout, stderr = self._run_command(cmd, timeout=300)
-
-        duration = time.time() - start_time
-        success = returncode == 0
-
-        # Get version after installation for version-tracked tools
-        version_after = None
-        if name in ["codex", "claude-code"]:  # Removed opencode
-            if name == "codex":
-                version_after = self._get_version("codex")
-            elif name == "claude-code":
-                version_after = self._get_version("claude")
-            # elif name == "opencode":  # Commented out - OpenCode disabled
-            #     version_after = self._get_version("opencode")
-
-        if success:
-            message = f"Successfully installed {name}"
-            if progress and task_id is not None:
+            if result.success:
                 progress.update(task_id, description=f"[green]✓ {name}[/green]")
-        else:
-            message = f"Failed to install {name}"
-            if progress and task_id is not None:
+            else:
                 progress.update(task_id, description=f"[red]✗ {name}[/red]")
 
-        return InstallResult(
-            name=name,
-            success=success,
-            message=message,
-            output=stdout,
-            error=stderr,
-            duration=duration,
-            version_before=version_before,
-            version_after=version_after
-        )
+        return result
 
     def install_tools(self, update_mode: bool = False) -> None:
         """Install all tools with progress tracking"""
-        # Check if we're in local-commands-only mode
         is_local_mode = hasattr(self, 'commands_local') and self.commands_local
 
         if is_local_mode:
-            # In local mode, only run agents.sh
-            agents_installer = self.install_path / "agents.sh"
-            if not agents_installer.exists():
-                console.print(f"[red]agents.sh installer not found at {agents_installer}[/red]")
-                return
-            installers = [agents_installer]
+            # In local mode, only run agents
+            steps = [("agents", lambda: self.installer.install_agents(
+                clear_mcp=self.clear_mcp,
+                commands_local=self.commands_local,
+                local_dir=self.local_dir,
+            ))]
             action = "install local commands"
         else:
-            # Standard mode: get all installers
-            installers = self.get_installers()
-            if not installers:
-                console.print("[yellow]No installers found[/yellow]")
-                return
+            steps = self.get_install_steps()
             action = "update" if update_mode else "install"
 
-        console.print(f"\n[bold cyan]Found {len(installers)} installer(s) to {action}[/bold cyan]\n")
+        console.print(f"\n[bold cyan]Found {len(steps)} installer(s) to {action}[/bold cyan]\n")
 
         with Progress(
             SpinnerColumn(),
@@ -452,13 +208,12 @@ class SetupManager:
             TimeRemainingColumn(),
             console=console,
         ) as progress:
-            # Sequential installation
             action_title = "Updating" if update_mode else "Installing"
-            overall_task = progress.add_task(f"[cyan]{action_title} tools...[/cyan]", total=len(installers))
+            overall_task = progress.add_task(f"[cyan]{action_title} tools...[/cyan]", total=len(steps))
 
-            for installer in installers:
-                task = progress.add_task(f"[cyan]{action_title} {installer.stem}...[/cyan]", total=1)
-                result = self.run_installer(installer, progress, task, update_mode)
+            for name, fn in steps:
+                task = progress.add_task(f"[cyan]{action_title} {name}...[/cyan]", total=1)
+                result = self.run_install_step(name, fn, progress, task)
                 self.results.append(result)
                 progress.update(task, completed=1)
                 progress.update(overall_task, advance=1)
@@ -544,6 +299,59 @@ class SetupManager:
                     console.print("[dim]Standard output:[/dim]")
                     console.print(Text(result.output[:500], style="dim"))
 
+    def dry_run(self) -> None:
+        """Show what would be installed and check prerequisites."""
+        console.print(Panel.fit(
+            "[bold cyan]Tools Repository Setup Manager[/bold cyan]\n"
+            f"[dim]OS: {self.os_type} | Path: {self.script_dir}[/dim]\n"
+            "[yellow]DRY RUN — no changes will be made[/yellow]",
+            border_style="cyan"
+        ))
+        console.print()
+
+        report = self.installer.preflight()
+
+        table = Table(title="Installation Plan", box=box.ROUNDED)
+        table.add_column("Tool", style="cyan", no_wrap=True)
+        table.add_column("Status", justify="center")
+        table.add_column("Action", no_wrap=False)
+        table.add_column("Prerequisites", no_wrap=False)
+
+        ready = skip = blocked = 0
+        for step in report:
+            # Status badge
+            if step["status"] == "skip":
+                status = "[green]✓ Installed[/green]"
+                skip += 1
+            elif step["status"] == "ready":
+                status = "[cyan]● Ready[/cyan]"
+                ready += 1
+            else:
+                status = "[red]✗ Blocked[/red]"
+                blocked += 1
+
+            # Prerequisites column
+            prereq_parts = []
+            for p in step["prereqs"]:
+                icon = "[green]✓[/green]" if p["found"] else "[red]✗[/red]"
+                prereq_parts.append(f"{icon} {p['name']}")
+            prereqs_str = ", ".join(prereq_parts) if prereq_parts else "[dim]none[/dim]"
+
+            # Action/reason
+            action = step.get("reason") or step["action"]
+
+            table.add_row(step["name"], status, action, prereqs_str)
+
+        console.print(table)
+        console.print()
+        console.print(f"[bold]Summary:[/bold]  "
+                      f"[cyan]{ready} ready[/cyan]  "
+                      f"[green]{skip} already installed[/green]  "
+                      f"[red]{blocked} blocked[/red]")
+        if blocked:
+            console.print("\n[yellow]Install missing prerequisites to unblock the blocked steps.[/yellow]")
+        console.print()
+
     def run(self, update_mode: bool = False) -> None:
         """Run the complete setup process"""
         # Check if we're in local-commands-only mode
@@ -610,7 +418,7 @@ class SetupManager:
             if self.is_windows:
                 console.print(Panel(
                     "[green]Setup complete![/green]\n\n"
-                    "Tools have been installed via Git Bash.\n"
+                    "Tools have been installed natively (no bash required).\n"
                     "Open a new terminal window to use the tools.",
                     border_style="green"
                 ))

--- a/src/jk_tools/setup_manager.py
+++ b/src/jk_tools/setup_manager.py
@@ -8,6 +8,7 @@ import os
 import sys
 import subprocess
 import platform
+import shutil
 import time
 from pathlib import Path
 from typing import List, Tuple, Optional
@@ -65,9 +66,11 @@ class SetupManager:
 
         self.scripts_path = self.script_dir / "scripts"
         self.install_path = self.script_dir / "install"
-        self.shell_config = Path.home() / ".zshrc"
         self.path_marker = "# Added by tools repository setup"
         self.os_type = self._detect_os()
+        self.is_windows = self.os_type == "Windows"
+        self.path_sep = ";" if self.is_windows else ":"
+        self.shell_config = Path.home() / ".zshrc"
         self.results: List[InstallResult] = []
 
         # Optional flags (set by main())
@@ -75,6 +78,11 @@ class SetupManager:
         self.commands_local = ""
         self.local_dir = str(Path.cwd())
         self.verbose = False
+
+        # Cache bash path on Windows
+        self._bash_path: Optional[str] = None
+        if self.is_windows:
+            self._bash_path = self._find_bash()
 
     def _detect_os(self) -> str:
         """Detect the operating system"""
@@ -87,6 +95,30 @@ class SetupManager:
             return "Windows"
         else:
             return "Unknown"
+
+    def _find_bash(self) -> Optional[str]:
+        """Find a usable bash executable on Windows"""
+        # Prefer Git Bash as it handles Windows paths natively
+        git_bash_paths = [
+            r"C:\Program Files\Git\bin\bash.exe",
+            r"C:\Program Files (x86)\Git\bin\bash.exe",
+        ]
+        for p in git_bash_paths:
+            if os.path.isfile(p):
+                return p
+
+        # Fall back to any bash on PATH (e.g. WSL bash)
+        bash = shutil.which("bash")
+        if bash:
+            return bash
+
+        return None
+
+    def _get_cargo_home(self) -> str:
+        """Get the Cargo home directory, OS-aware"""
+        if self.is_windows:
+            return str(Path.home() / ".cargo" / "bin")
+        return f"{os.environ.get('HOME', '')}/.cargo/bin"
 
     def _run_command(self, cmd: List[str], timeout: Optional[int] = None) -> Tuple[int, str, str]:
         """Run a command and return exit code, stdout, and stderr"""
@@ -113,16 +145,28 @@ class SetupManager:
                     continue
                 clean_env[k] = v
 
-            # Add Cargo to PATH
-            clean_env["PATH"] = f"{os.environ.get('HOME', '')}/.cargo/bin:{os.environ.get('PATH', '')}"
+            # Add Cargo to PATH (OS-aware separator)
+            cargo_home = self._get_cargo_home()
+            clean_env["PATH"] = f"{cargo_home}{self.path_sep}{os.environ.get('PATH', '')}"
 
-            # If executing a shell script, wrap with bash -p (privileged mode)
-            # -p tells bash to ignore BASH_ENV and ENV completely
-            # NOTE: Long options must come BEFORE short options for bash 3.2 compatibility
+            # If executing a shell script, wrap with bash
             if cmd and cmd[0].endswith('.sh'):
                 script = cmd[0]
                 args = cmd[1:]
-                cmd = ["/bin/bash", "--noprofile", "--norc", "-p", script, *args]
+                if self.is_windows:
+                    if not self._bash_path:
+                        return -1, "", (
+                            "No bash found on Windows. Install Git for Windows "
+                            "(https://git-scm.com) to get Git Bash, or install WSL."
+                        )
+                    cmd = [self._bash_path, "--noprofile", "--norc", "-p", script, *args]
+                else:
+                    # NOTE: Long options must come BEFORE short options for bash 3.2 compatibility
+                    cmd = ["/bin/bash", "--noprofile", "--norc", "-p", script, *args]
+
+            # If executing a Python script directly, prepend the interpreter
+            if cmd and cmd[0].endswith('.py'):
+                cmd = [sys.executable, *cmd]
 
             result = subprocess.run(
                 cmd,
@@ -147,7 +191,7 @@ class SetupManager:
                 if k in problematic_vars or k.startswith("BASH_FUNC_"):
                     continue
                 clean_env[k] = v
-            clean_env["PATH"] = f"{os.environ.get('HOME', '')}/.cargo/bin:{os.environ.get('PATH', '')}"
+            clean_env["PATH"] = f"{self._get_cargo_home()}{self.path_sep}{os.environ.get('PATH', '')}"
 
             result = subprocess.run(
                 [command, "--version"],
@@ -182,6 +226,18 @@ class SetupManager:
 
     def add_to_path(self) -> bool:
         """Add scripts directory to PATH"""
+        if self.is_windows:
+            # On Windows, add to the current session PATH only.
+            current_path = os.environ.get("PATH", "")
+            if str(self.scripts_path) not in current_path:
+                os.environ["PATH"] = f"{self.scripts_path};{current_path}"
+                console.print(f"[green]✓[/green] Scripts directory added to current session PATH")
+            else:
+                console.print(f"[yellow]•[/yellow] Scripts directory already in PATH")
+            console.print(f"[dim]  To persist, add to your User PATH via System Environment Variables:[/dim]")
+            console.print(f"[dim]  {self.scripts_path}[/dim]")
+            return True
+
         path_export = f'export PATH="{self.scripts_path}:$PATH"'
 
         # Check if already in shell config
@@ -210,6 +266,13 @@ class SetupManager:
         """Make all scripts in the scripts directory executable"""
         if not self.scripts_path.exists():
             return 0
+
+        if self.is_windows:
+            # chmod is not meaningful on Windows
+            script_count = sum(1 for s in self.scripts_path.iterdir() if s.is_file())
+            if script_count > 0:
+                console.print(f"[green]✓[/green] Found {script_count} script(s) (chmod not needed on Windows)")
+            return script_count
 
         script_count = 0
         for script in self.scripts_path.iterdir():
@@ -288,8 +351,9 @@ class SetupManager:
             action = "Updating" if update_mode else "Installing"
             progress.update(task_id, description=f"[cyan]{action} {name}...[/cyan]")
 
-        # Make installer executable
-        installer.chmod(0o755)
+        # Make installer executable (no-op on Windows)
+        if not self.is_windows:
+            installer.chmod(0o755)
 
         # Build command with update flag if needed
         cmd = [str(installer)]
@@ -543,13 +607,21 @@ class SetupManager:
             self.show_summary()
 
             # Final message
-            console.print(Panel(
-                "[green]Setup complete![/green]\n\n"
-                "To use the changes in your current shell:\n"
-                "  [cyan]source ~/.zshrc[/cyan]\n\n"
-                "Or simply open a new terminal window.",
-                border_style="green"
-            ))
+            if self.is_windows:
+                console.print(Panel(
+                    "[green]Setup complete![/green]\n\n"
+                    "Tools have been installed via Git Bash.\n"
+                    "Open a new terminal window to use the tools.",
+                    border_style="green"
+                ))
+            else:
+                console.print(Panel(
+                    "[green]Setup complete![/green]\n\n"
+                    "To use the changes in your current shell:\n"
+                    "  [cyan]source ~/.zshrc[/cyan]\n\n"
+                    "Or simply open a new terminal window.",
+                    border_style="green"
+                ))
 
 
 def main():


### PR DESCRIPTION
## Summary

Running `uvx --from git+https://github.com/jakkaj/tools jk-tools-setup` failed on Windows (0/10 installers succeeded). The root cause was an architecture that piped Python → bash → tool commands, which broke anywhere bash wasn't available.

## What changed

### Architecture rewrite: bash scripts → pure Python

The actual tool commands (`npm install`, `cargo install`, `curl`, etc.) are **already cross-platform**. The bash wrappers added nothing but fragility. This PR replaces them with a single Python module that calls those commands directly via `subprocess.run()`.

| Before | After |
|--------|-------|
| `setup_manager.py` → \\/bin/bash\\ → \\.sh\\ script → \\
pm install\\ | `setup_manager.py` → `installers.py` → `npm install` |
| 10 bash scripts + 2 Python scripts | 1 Python module (`installers.py`) |
| 0/10 on Windows | 7/9 on Windows |

### New file: `src/jk_tools/installers.py`

A `ToolInstaller` class with one method per tool:

- **Simple installers**: `install_just()`, `install_rust()`, `install_code2prompt()`, `install_fs2()`, `install_claude_code()`, `install_codex()`, `install_copilot_cli()`, `install_aliases()`
- **Complex installer**: `install_agents()` — full port of the 1000-line `agents.sh` (MCP config generation from `servers.json`, v2-commands file copying, Copilot CLI agent generation with YAML frontmatter, local commands mode)
- **Preflight system**: `preflight()` returns a check of every step's prerequisites before running anything

### New feature: `--dry-run` / `-n`

Shows what would be installed, what's already present, and what prerequisites are missing — without making any changes:

\\\
$ jk-tools-setup --dry-run

┌─────────────┬─────────────┬──────────────────────────────────┬───────────────┐
│ Tool        │ Status      │ Action                           │ Prerequisites │
├─────────────┼─────────────┼──────────────────────────────────┼───────────────┤
│ just        │ ✓ Installed │ Already installed (just 1.46.0)  │ none          │
│ rust        │ ✓ Installed │ Already installed (cargo 1.93.1) │ none          │
│ code2prompt │ ● Ready     │ cargo install code2prompt        │ ✓ cargo       │
│ fs2         │ ✓ Installed │ Already installed (fs2 v0.1.0)   │ ✓ uvx         │
│ agents      │ ● Ready     │ Copy v2-commands, generate MCP   │ ✓ v2-commands │
│ claude-code │ ● Ready     │ npm install -g claude-code       │ ✓ npm         │
│ codex       │ ● Ready     │ npm install -g @openai/codex     │ ✓ npm         │
│ copilot-cli │ ✓ Installed │ Already installed (0.0.421)      │ ✓ npm         │
│ aliases     │ ● Ready     │ Generate ~/.tools_aliases        │ none          │
└─────────────┴─────────────┴──────────────────────────────────┴───────────────┘
Summary:  5 ready  4 already installed  0 blocked
\\\

### Modified: `src/jk_tools/setup_manager.py`

- Removed all bash-wrapping code (`_run_command`, `_find_bash`, `_get_cargo_home`, `get_installers`, etc.)
- Uses `ToolInstaller` methods directly instead of `.sh` file discovery
- Added `dry_run()` method

### Other fixes

- `install/aliases.py`: Replaced `subprocess(['which', ...])` with `shutil.which()`
- `install/rust.sh`: Added MINGW/MSYS/CYGWIN case for Windows Git Bash
- `install/claude-code.sh`, `install/codex.sh`: Fixed npm prefix PATH for Windows
- `install/coding_tools_installer.py`: Added `--verbose`/`--no-auto-sudo` flags

## Backward compatibility

Existing `.sh` files are retained in `install/` for anyone running them standalone. They are no longer invoked by `setup_manager.py`.

## Testing

Tested on Windows 11 via `uvx --from . jk-tools-setup`:
- **Before**: 0/10 succeeded
- **After**: 7/9 succeeded (2 failures: `code2prompt` cargo compile timeout, `agents` missing API key — both expected)
- `--dry-run` mode verified working
- Existing pytest suite: 14/14 passing tests still pass (4 pre-existing Windows failures unchanged)
